### PR TITLE
MWScriptJob: use run.php wrapper for MediaWiki 1.40

### DIFF
--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -36,7 +36,7 @@ class MWScriptJob extends Job {
 		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
 			$scriptOptions = [ 'wrapper' => MW_INSTALL_PATH . '/maintenance/run.php' ];
 		}
-	
+
 		$result = Shell::makeScriptCommand(
 			$this->params['script'],
 			$scriptParams,


### PR DESCRIPTION
This is the default on MediaWiki 1.41+ but is good for MediaWiki 1.40 also.